### PR TITLE
fix: Add support for mac_os_x platform version 13 (OS X 10.13 High Si…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,9 @@ if node['platform_family'] == 'mac_os_x'
   when 12
     default['macports']['url'] = 'http://downloads.sourceforge.net/project/macports/MacPorts/2.3.4/MacPorts-2.3.4-10.12-Sierra.pkg'
     default['macports']['checksum'] = '0fda4bfcbd922e20b489c762ee6d755d63df5a1e5f3666f71af95d96c9d398c8'
+  when 13
+    default['macports']['url'] = 'https://github.com/macports/macports-base/releases/download/v2.4.1/MacPorts-2.4.1-10.13-HighSierra.pkg'
+    default['macports']['checksum'] = 'c87c044862fe05c0ce8618ab09976b90551d1d04ecc9cc4ceb454f9e54b6a620'
   else
     fail "Unsupported platform version #{node['platform_version']}"
   end


### PR DESCRIPTION
# Jira link
https://issues.jboss.org/browse/RHMAP-20373

# What
Update the macports cookbook to support OSX 10.13 

# Why
chef-client does not support that version of OSX without this change and Meh2 osx1 instance which runs OSX 10.13 cannot be re-cheffed. 

# How
Update our fork of the macports cookbook to point to the macports binary for 10.13, and include the accompanying SHA256 hash. Version of macports for 10.13 also needed to be updated to v2.4.1 as previous version did not support High Sierra.

# Verification steps
- run the chef-client on an osx digger instance that is running osx10.13 (such as meh2) to verify changes correct issue 